### PR TITLE
Assorted GPU apriltag changes from your friends at FRC900

### DIFF
--- a/frc971/orin/apriltag.h
+++ b/frc971/orin/apriltag.h
@@ -208,8 +208,6 @@ class GpuDetector {
 
   // Undistort pixels based on our camera model, using iterative algorithm
   // Returns false if we fail to converge
-  // Make this a free function rather than a static member function to make
-  // remove the need for callers to know the template arg from GpuDetector
   static bool UnDistort(double *u, double *v, const CameraMatrix *camera_matrix,
                         const DistCoeffs *distortion_coefficients);
 

--- a/frc971/orin/apriltag_detect.cc
+++ b/frc971/orin/apriltag_detect.cc
@@ -630,6 +630,9 @@ void GpuDetector::QuadDecodeTask(void *_u) {
 
     quad_decode_index(td, &quad_original, im, task->im_samples,
                       task->detections);
+
+    if (quad_original.H) matd_destroy(quad_original.H);
+    if (quad_original.Hinv) matd_destroy(quad_original.Hinv);
   }
 }
 

--- a/frc971/orin/apriltag_detect.cc
+++ b/frc971/orin/apriltag_detect.cc
@@ -519,7 +519,8 @@ void RefineEdges(apriltag_detector_t *td, image_u8_t *im_orig,
       double bestx = x0 + n0 * nx;
       double besty = y0 + n0 * ny;
 
-      GpuDetector::UnDistort(&bestx, &besty, camera_matrix, distortion_coefficients);
+      GpuDetector::UnDistort(&bestx, &besty, camera_matrix,
+                             distortion_coefficients);
 
       // update our line fit statistics
       Mx += bestx;

--- a/frc971/orin/apriltag_input_format.h
+++ b/frc971/orin/apriltag_input_format.h
@@ -1,0 +1,16 @@
+#ifndef FRC971_ORIN_APRILTAG_INPUT_FORMAT_H_
+#define FRC971_ORIN_APRILTAG_INPUT_FORMAT_H_
+
+namespace frc971::apriltag {
+
+enum class InputFormat {
+  Mono8,
+  Mono16,
+  YCbCr422,
+  BGR8,
+  BGRA8,
+};
+
+} // namespace frc971::apriltag
+
+#endif

--- a/frc971/orin/cuda.cc
+++ b/frc971/orin/cuda.cc
@@ -11,6 +11,10 @@ namespace frc971::apriltag {
 
 size_t overall_memory = 0;
 
+void CudaStream::Wait(CudaEvent *event) {
+  CHECK_CUDA(cudaStreamWaitEvent(stream_, event->get(), 0));
+}
+
 void CheckAndSynchronize(std::string_view message) {
   CHECK_CUDA(cudaDeviceSynchronize()) << message;
   CHECK_CUDA(cudaGetLastError()) << message;

--- a/frc971/orin/cuda.h
+++ b/frc971/orin/cuda.h
@@ -143,31 +143,11 @@ class GpuMemory {
   }
   GpuMemory(const GpuMemory &) = delete;
 
-  // Create an alias to an already allocated GPU memory block.
-  // This is useful for cases where operations on memory are a no-op
-  //   for certain input types - for example, for mono input imnages,
-  //   the GPU "color" image is the same as the one converted to grayscale.
-  GpuMemory &operator=(const GpuMemory &other) {
-    // If we currently own our memory, free it.
-    if (owns_memory_) {
-      CHECK_CUDA(cudaFree(memory_));
-    }
-
-    // Copy the memory pointer and size, making
-    // this an alias to the input GpuMemory object's data.
-    memory_ = other.memory_;
-    size_ = other.size_;
-    owns_memory_ = false;
-
-    return *this;
-  }
   GpuMemory(const GpuMemory &&) noexcept = delete;
   GpuMemory &operator=(const GpuMemory &&) noexcept = delete;
 
   virtual ~GpuMemory() {
-    if (owns_memory_) {
-      CHECK_CUDA(cudaFree(memory_));
-    }
+    CHECK_CUDA(cudaFree(memory_));
   }
 
   // Returns the device pointer to the memory.
@@ -254,7 +234,6 @@ class GpuMemory {
  private:
   T *memory_;
   size_t size_;
-  bool owns_memory_{true};
 };
 
 // Synchronizes and CHECKs for success the last CUDA operation.

--- a/frc971/orin/cuda_april_tag_test.cc
+++ b/frc971/orin/cuda_april_tag_test.cc
@@ -2120,7 +2120,7 @@ class CudaAprilTagDetector {
   int num_quads_ = 0;
   std::vector<QuadCorners> fit_quads_;
 
-  GpuDetector gpu_detector_;
+  GpuDetector<frc971::apriltag::InputFormat::YCbCr422> gpu_detector_;
 
   zarray_t *aprilrobotics_detections_ = nullptr;
 

--- a/frc971/orin/cuda_event_timing.cc
+++ b/frc971/orin/cuda_event_timing.cc
@@ -1,0 +1,155 @@
+#include "frc971/orin/cuda_event_timing.h"
+#include "frc971/orin/cuda_utils.h"
+#include "nvToolsExt.h"
+#include <iostream>
+
+Timing::Timing(const std::string &name)
+    : m_name{name}
+{
+    cudaSafeCall(cudaEventCreate(&m_startEvent));
+    cudaSafeCall(cudaEventCreate(&m_endEvent));
+}
+
+Timing::~Timing()
+{
+    cudaSafeCall(cudaEventDestroy(m_startEvent));
+    cudaSafeCall(cudaEventDestroy(m_endEvent));
+}
+
+void Timing::start(cudaStream_t cudaStream)
+{
+    if (m_startEventSeen)
+    {
+        if (m_endEventSeen)
+        {
+            endFrame();
+        }
+        else
+        {
+            std::cerr << "Error : duplicate start event " << m_name << " seen." << std::endl;
+        }
+    }
+    m_cudaStream = cudaStream;
+    cudaSafeCall(cudaEventRecord(m_startEvent, cudaStream));
+    nvtxRangePushA(m_name.c_str());
+
+    m_startEventSeen = true;
+}
+
+void Timing::end(void)
+{
+    if (m_endEventSeen)
+    {
+        std::cerr << "Error : duplicate end event " << m_name << " seen." << std::endl;
+    }
+    cudaSafeCall(cudaEventRecord(m_endEvent, m_cudaStream));
+    nvtxRangePop();
+
+    m_endEventSeen = true;
+}
+
+void Timing::endFrame(void)
+{
+    if (m_startEventSeen && m_endEventSeen)
+    {
+        // cudaSafeCall(cudaEventSynchronize(m_startEvent)); Shouldn't need this one - if end has been seen, the corresponding start event has also occurred
+        cudaSafeCall(cudaEventSynchronize(m_endEvent));
+        m_startEventSeen = false;
+        m_endEventSeen = false;
+        if (++m_count > 0)
+        {
+            float elapsedTime;
+            cudaSafeCall(cudaEventElapsedTime(&elapsedTime, m_startEvent, m_endEvent));
+            m_elapsedSeconds += elapsedTime;
+        }
+    }
+}
+
+std::ostream &operator<<(std::ostream &stream, const Timing &timing)
+{
+    if (timing.m_count <= 0)
+    {
+        stream << timing.m_name << " : no events recorded";
+    }
+    else
+    {
+        stream << timing.m_name << " : " << timing.m_count << " events. Total time = " << timing.m_elapsedSeconds << " average mSec = " << (timing.m_elapsedSeconds / timing.m_count);
+    }
+    return stream;
+}
+
+Timings::Timings() = default;
+
+Timings::~Timings()
+{
+    endFrame();
+    std::cout << *this << std::endl;
+}
+
+void Timings::start(const std::string &name, cudaStream_t cudaStream)
+{
+    if (m_enabled)
+    {
+        const auto &[it, placed] = m_timings.try_emplace(name, name);
+        if (placed)
+        {
+            m_keys_in_insert_order_.push_back(name);
+        }
+        it->second.start(cudaStream);
+    }
+}
+
+void Timings::end(const std::string &name)
+{
+    if (m_enabled)
+    {
+        auto it = m_timings.find(name);
+        if (it == m_timings.end())
+        {
+            std::cerr << " Error - end called before start for " << name << std::endl;
+            return;
+        }
+        it->second.end();
+    }
+}
+
+void Timings::endFrame(void)
+{
+    if (m_enabled)
+    {
+        for (auto &[name, timing] : m_timings)
+        {
+            timing.endFrame();
+        }
+    }
+}
+
+void Timings::setEnabled(const bool enabled)
+{
+    if (m_enabled && !enabled)
+    {
+        endFrame();
+    }
+    m_enabled = enabled;
+}
+
+std::ostream &operator<<(std::ostream &stream, const Timings &timings)
+{
+    for (const auto &name : timings.m_keys_in_insert_order_)
+    {
+        stream << timings.m_timings.at(name) << std::endl;
+    }
+    return stream;
+}
+
+ScopedEventTiming::ScopedEventTiming(Timings &timings, const std::string &name, cudaStream_t cudaStream)
+    : m_timings{timings}
+    , m_name{name}
+{
+    m_timings.start(m_name, cudaStream);
+}
+
+ScopedEventTiming::~ScopedEventTiming()
+{
+    m_timings.end(m_name);
+}

--- a/frc971/orin/cuda_event_timing.h
+++ b/frc971/orin/cuda_event_timing.h
@@ -1,0 +1,82 @@
+#ifndef CUDA_EVENT_TIMING_INC__
+#define CUDA_EVENT_TIMING_INC__
+#include <iosfwd>          // for ostream
+#include <map>             // for map
+#include <string>          // for string
+#include <vector>          // for vector
+#include "driver_types.h"  // for cudaStream_t, CUevent_st, cudaEvent_t
+
+class Timing
+{
+public:
+    explicit Timing(const std::string &name);
+
+    Timing(const Timing &other) = delete;
+    Timing(Timing &&other) noexcept = default;
+
+    Timing &operator=(const Timing &other) = delete;
+    Timing &operator=(Timing &&other) noexcept = default;
+
+    virtual ~Timing();
+   
+    void start(cudaStream_t cudaStream);
+    void end(void);
+    void endFrame(void);
+    friend std::ostream &operator<<(std::ostream &stream, const Timing &timing);
+private:
+    std::string m_name;
+    cudaEvent_t m_startEvent{};
+    cudaEvent_t m_endEvent{};
+    cudaStream_t m_cudaStream{};
+    bool m_startEventSeen{false};
+    bool m_endEventSeen{false};
+    double m_elapsedSeconds{0};
+    long int m_count{-5}; // start negative to allow warm up before counting events
+};
+
+class Timings
+{
+public:
+    Timings();
+    Timings(const Timings &other) = delete;
+    Timings(Timings &&other) noexcept = delete;
+
+    Timings &operator=(const Timings &other) = delete;
+    Timings &operator=(Timings &&other) noexcept = delete;
+
+    virtual ~Timings();
+
+    void start(const std::string &name, cudaStream_t cudaStream);
+    void end(const std::string &name);
+
+    void endFrame(void);
+
+    void setEnabled(const bool enabled);
+
+    friend std::ostream &operator<<(std::ostream &stream, const Timings &timings);
+
+private:
+    std::map<std::string, Timing> m_timings{};
+    std::vector<std::string> m_keys_in_insert_order_{};
+    bool m_enabled{true};
+};
+
+class ScopedEventTiming
+{
+public:
+    ScopedEventTiming(Timings &timings, const std::string &name, cudaStream_t cudaStream);
+    ScopedEventTiming(const ScopedEventTiming &other) = delete;
+    ScopedEventTiming(ScopedEventTiming &&other) noexcept = delete;
+
+    ScopedEventTiming &operator=(const ScopedEventTiming &other) = delete;
+    ScopedEventTiming &operator=(ScopedEventTiming &&other) noexcept = delete;
+
+    virtual ~ScopedEventTiming();
+
+private:
+    Timings &m_timings;
+    std::string m_name;
+};
+
+
+#endif

--- a/frc971/orin/cuda_utils.cc
+++ b/frc971/orin/cuda_utils.cc
@@ -1,0 +1,17 @@
+#include <iostream>
+#include "frc971/orin/cuda_utils.h"
+
+void cudaSafeCallWrapper(cudaError err, const char* file, const int line)
+{
+	if (cudaSuccess != err)
+	{
+		std::cout << "=================================================" << std::endl <<
+		             "CUDA error : " << std::endl <<
+                    "\tFile: " << file << std::endl <<
+                    "\tLine Number: " << line << std::endl <<
+                    "\tReason: " << cudaGetErrorString(err) << std::endl <<
+					"=================================================" << std::endl;
+		//cudaDeviceReset();
+		//exit(EXIT_FAILURE);
+	}
+}

--- a/frc971/orin/cuda_utils.h
+++ b/frc971/orin/cuda_utils.h
@@ -1,0 +1,14 @@
+#ifndef CUDA_UTILS_INC_
+#define CUDA_UTILS_INC_
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#ifndef cudaSafeCall
+#define cudaSafeCall(call) cudaSafeCallWrapper((call),__FILE__,__LINE__)
+#endif
+
+void cudaSafeCallWrapper(cudaError err, const char* file, const int line);
+
+inline __device__ __host__ uint32_t iDivUp( uint32_t a, uint32_t b )  		{ return (a % b != 0) ? (a / b + 1) : (a / b); }
+
+#endif

--- a/frc971/orin/gpu_apriltag.h
+++ b/frc971/orin/gpu_apriltag.h
@@ -113,7 +113,7 @@ class ApriltagDetector {
   CameraMatrix distortion_camera_matrix_;
   DistCoeffs distortion_coefficients_;
 
-  frc971::apriltag::GpuDetector gpu_detector_;
+  frc971::apriltag::GpuDetector<frc971::apriltag::InputFormat::YCbCr422> gpu_detector_;
   cv::Size image_size_;
 
   frc971::vision::ImageCallback image_callback_;

--- a/frc971/orin/labeling_allegretti_2019_BKE.cc
+++ b/frc971/orin/labeling_allegretti_2019_BKE.cc
@@ -397,7 +397,7 @@ __global__ void FinalLabeling(GpuImage<uint32_t> labels,
 
   if ((foreground_info & 0xf) != 0u) {
     // We've got foreground!
-    size_t count = 0;
+    uint32_t count = 0;
     if (HasBit(foreground_info, Info::a)) {
       ++count;
     }
@@ -423,7 +423,7 @@ __global__ void FinalLabeling(GpuImage<uint32_t> labels,
       (background_right_info & 0xf) != 0u &&
       background_left_label == background_right_label) {
     // They are all populated and match, go for it.
-    size_t count = 0;
+    uint32_t count = 0;
     if (HasBit(background_left_info, Info::a)) {
       ++count;
     }
@@ -442,7 +442,7 @@ __global__ void FinalLabeling(GpuImage<uint32_t> labels,
   }
 
   if ((background_left_info & 0xf) != 0u) {
-    size_t count = 0;
+    uint32_t count = 0;
     if (HasBit(background_left_info, Info::a)) {
       ++count;
     }
@@ -453,7 +453,7 @@ __global__ void FinalLabeling(GpuImage<uint32_t> labels,
   }
 
   if ((background_right_info & 0xf) != 0u) {
-    size_t count = 0;
+    uint32_t count = 0;
     if (HasBit(background_right_info, Info::b)) {
       ++count;
     }

--- a/frc971/orin/labeling_allegretti_2019_BKE.h
+++ b/frc971/orin/labeling_allegretti_2019_BKE.h
@@ -1,6 +1,7 @@
 #ifndef FRC971_ORIN_LABELING_ALLEGRETTI_2019_BKE_H_
 #define FRC971_ORIN_LABELING_ALLEGRETTI_2019_BKE_H_
 
+#include <cstdint>
 #include <cuda_runtime.h>
 
 #include "frc971/orin/gpu_image.h"

--- a/frc971/orin/line_fit_filter.cc
+++ b/frc971/orin/line_fit_filter.cc
@@ -217,7 +217,7 @@ class ErrorCalculator {
 
   // Calculates the line fit error centered on the provided blob index in the
   // current extent.
-  __host__ __device__ double CalculateError(ssize_t blob_index,
+  __device__ double CalculateError(ssize_t blob_index,
                                             bool print = false) const {
     // Index into the blob list for the current key.
     const size_t i0 = (blob_index + 2 * count_ - ksz_) % count_;
@@ -939,7 +939,7 @@ class QuadFitCalculator {
         line_fit_points_device_, selected_extent_.count, index0, index1);
   }
 
-  __host__ __device__ void ComputeM0M1Fit() {
+  __device__ void ComputeM0M1Fit() {
     if (extents_.count < 4) {
       return;
     }
@@ -979,7 +979,7 @@ class QuadFitCalculator {
 
   __host__ __device__ int blob_index() const { return extents_.blob_index; }
 
-  __host__ __device__ double FitLines(uint m0, uint m1, uint m2,
+  __device__ double FitLines(uint m0, uint m1, uint m2,
                                       uint m3) const {
     const bool print =
 #ifdef DEBUG_BLOB_NUMBER

--- a/frc971/orin/line_fit_filter.cc
+++ b/frc971/orin/line_fit_filter.cc
@@ -218,7 +218,7 @@ class ErrorCalculator {
   // Calculates the line fit error centered on the provided blob index in the
   // current extent.
   __device__ double CalculateError(ssize_t blob_index,
-                                            bool print = false) const {
+                                   bool print = false) const {
     // Index into the blob list for the current key.
     const size_t i0 = (blob_index + 2 * count_ - ksz_) % count_;
     const size_t i1 = (blob_index + count_ + ksz_) % count_;

--- a/frc971/orin/line_fit_filter.h
+++ b/frc971/orin/line_fit_filter.h
@@ -41,20 +41,20 @@ struct MinMaxExtents {
   int64_t pxgx_plus_pygy_sum;
 
   // Center location of the blob using the aprilrobotics algorithm.
-  __host__ __device__ double cx() const {
-    return (min_x + max_x) * 0.5f + 0.05118;
+  __host__ __device__ float cx() const {
+    return (min_x + max_x) * 0.5f + 0.05118f;
   }
-  __host__ __device__ double cy() const {
-    return (min_y + max_y) * 0.5f + -0.028581;
+  __host__ __device__ float cy() const {
+    return (min_y + max_y) * 0.5f + -0.028581f;
   }
 
   __host__ __device__ float dot() const {
-    return static_cast<double>(pxgx_plus_pygy_sum * 2 -
+    return static_cast<float>(pxgx_plus_pygy_sum * 2 -
                                (min_x + max_x) * gx_sum -
                                (min_y + max_y) * gy_sum) *
-               0.5 -
-           0.05118 * static_cast<double>(gx_sum) +
-           0.028581 * static_cast<double>(gy_sum);
+               0.5f -
+           0.05118f * static_cast<float>(gx_sum) +
+           0.028581f * static_cast<float>(gy_sum);
   }
 };
 

--- a/frc971/orin/points.h
+++ b/frc971/orin/points.h
@@ -108,10 +108,11 @@ struct QuadBoundaryPoint {
   }
 
   // Returns the un-decimated x and y positions.
-  __forceinline__ __host__ __device__ uint32_t x() const {
+  // TODO - this can be a uint16_t?
+  __forceinline__ __host__ __device__ uint16_t x() const {
     return static_cast<int32_t>(base_x() * 2) + dx();
   }
-  __forceinline__ __host__ __device__ uint32_t y() const {
+  __forceinline__ __host__ __device__ uint16_t y() const {
     return static_cast<int32_t>(base_y() * 2) + dy();
   }
 

--- a/frc971/orin/threshold.h
+++ b/frc971/orin/threshold.h
@@ -3,17 +3,47 @@
 
 #include <stdint.h>
 
+#include "frc971/orin/apriltag_input_format.h"
 #include "frc971/orin/cuda.h"
 
 namespace frc971::apriltag {
 
-// Converts to grayscale, decimates, and thresholds an image on the provided
-// stream.
-void CudaToGreyscaleAndDecimateHalide(
-    const uint8_t *color_image, uint8_t *gray_image, uint8_t *decimated_image,
-    uint8_t *unfiltered_minmax_image, uint8_t *minmax_image,
-    uint8_t *thresholded_image, size_t width, size_t height,
-    size_t min_white_black_diff, CudaStream *stream);
+class BaseThreshold
+{
+public:
+    // Create a full-size grayscale image from a color image on the provided stream.
+    virtual void CudaToGreyscale(const uint8_t *color_image, uint8_t *gray_image,
+                        uint32_t width, uint32_t height, CudaStream *stream) = 0;
+
+    // Converts to grayscale, decimates, and thresholds an image on the provided
+    // stream.
+    virtual void CudaToGreyscaleAndDecimateHalide(
+        const uint8_t *color_image, uint8_t *decimated_image,
+        uint8_t *unfiltered_minmax_image, uint8_t *minmax_image,
+        uint8_t *thresholded_image, uint32_t width, uint32_t height,
+        uint32_t min_white_black_diff, CudaStream *stream) = 0;
+
+    virtual ~BaseThreshold() = default;
+}; // class BaseThreshold
+
+template <InputFormat INPUT_FORMAT>
+class Threshold : public BaseThreshold
+{
+public:
+    // Create a full-size grayscale image from a color image on the provided stream.
+    void CudaToGreyscale(const uint8_t *color_image, uint8_t *gray_image,
+                        uint32_t width, uint32_t height, CudaStream *stream) override;
+
+    // Converts to grayscale, decimates, and thresholds an image on the provided
+    // stream.
+    void CudaToGreyscaleAndDecimateHalide(
+        const uint8_t *color_image, uint8_t *decimated_image,
+        uint8_t *unfiltered_minmax_image, uint8_t *minmax_image,
+        uint8_t *thresholded_image, uint32_t width, uint32_t height,
+        uint32_t min_white_black_diff, CudaStream *stream) override;
+
+    virtual ~Threshold() = default;
+}; // class Threshold
 
 }  // namespace frc971::apriltag
 


### PR DESCRIPTION
I know this is a huge number of diffs. I should have started it a while back but momentum got in the way and it has ended up here.  So this is one of those "the best time to plant a tree was 20 years ago, the second best is today" kind of efforts. I fully expect lots of back and forth before merging, no worries.  And there's certainly no obligation to take any of it. Hopefully the results of another set of eyes digging in will be useful but I won't be offended either way :) 

First and foremost - I haven't looked into how to build this for your setup, so I know there will be issues with it as-is.  I'd be happy to try, just not sure how much else of your environment I'd need to duplicate. Instructions welcome on that front.

It's a lot of code, here's my brain dump of the assorted changes and some rationale for them.
Right now for mono8 camera inputs I’m getting about 7-8msec runtime for decode on an Orin Nano. Perf is pretty similar on the Xavier NX which surprises me … the  GPU seems pretty full on both, and I’d have expected better GPU perf on Orin. Maybe memory bandwidth limits? In any case, we're successfully running 2x 2MP 60FPS mono cameras at camera frame rate so we're happy.

Almost all of the changes where code is broken out into separate include files is to make life easier for integrating with our external code. There’s probably a bit more work there (there’s copy-pasted code in our repo that could likely be extracted into common files) but it is certainly usable now.

Updated the code to be templated on the image input format.  Our cameras are either BGRA8 (8-bit blue, green, red + alpha channel) or  8-bit or 16-bit monochrome images. This change was a way to efficiently deal with the differences.  Most of the changes are in the initial input->grayscale conversion but there are a few optimizations for the mono8 case since, for example, the input->grayscale conversion in that case is a no-op.  
These changes were isolated to the initial image copy to device memory and conversion, so threshold.cc was templated on input type.

Part of this was also splitting the decimation kernel from the grayscale conversion code.  This helped perf for mono8 inputs, since the grayscale conversion code can be skipped entirely.  And the grayscale code can be split off into a separate stream since its results aren’t needed until the end of the cuda work … it can be held by sync primitives and scheduled to run when GPU work is minimal, getting some parallelism on the CUDA side.  The latter part can be improved, but since I’m mainly using mono inputs this is harder for me to test and tune.

Modified the code to handle non-multiple-of-8 input heights.  I did this in the cheapest way possible.  All internal buffers are allocated after rounding up to the next multiple of 8.  The decode function, however, copies the exact image size, meaning that some of the end of the GPU buffer will not be written in cases where the actual input isn’t a multiple of 8  The GPU image buffer is zeroed in its constructor so the data isn’t undefined. Having a few rows of all 0 pixels in the input doesn’t seem to make a difference in the results and was an easy way to support our camera resolutions.

I copied over code I had which collects timing info. It also marks ranges of code with ntvx markers so it is easy to see what is going on when using visual tools such as nsys-ui.  The printout code needs to be hooked up more cleanly (I was working to integrate glog code with ROS console printing but haven’t had a chance to make it work yet … once I do it’ll be easier to have a clean solution).
This means a lot of the existing timing code events are redundant, but I haven’t yet cleaned up any of it.

Did a bunch of work making sure everything runs on the correct CUDA stream, and at the same time moved everything off the default stream. This means all memcpy / memset code is async aside from some initialization.  Big changes here include

- Instead of sync memcpy calls into local int vars which are then passed to subsequent cub:: calls, queue up an async memcpy into a HostMemory array of size 1.  Then use cuda sync calls to hold the cub:: calls using those values from being submitted until after the memcpy is finished.
- Move a memset() off into a separate stream so it can run in parallel with other code execution
- The input->grayscale conversion code is also moved to a separate stream.
- There were a few cases where it looked like cub:: code was unintentionally being run on the default stream, that should be fixed.

Changed 64-bit values in GPU code to 32-bit where possible.  This provided a small but measurable speedup in some cases.  It’s especially important for double->float changes, but also size_t -> uint32_t had a bit of an impact.

